### PR TITLE
bugfix:Fix equals and notEquals predicates implicit conversions

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -224,6 +224,20 @@ object ScalarOperators {
     else if (isComparable(left.resultType) && left.resultType == right.resultType) {
       generateComparison("==", nullCheck, left, right)
     }
+    // string type and other type
+    else if (isString(left.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"$leftTerm.equals(String.valueOf($rightTerm))"
+      }
+    }
+    // other type and string type
+    else if (isString(right.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"$rightTerm.equals(String.valueOf($leftTerm))"
+      }
+    }
     // non comparable types
     else {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
@@ -271,6 +285,20 @@ object ScalarOperators {
     // comparable types
     else if (isComparable(left.resultType) && left.resultType == right.resultType) {
       generateComparison("!=", nullCheck, left, right)
+    }
+    // string type and other type
+    else if (isString(left.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"!($leftTerm.equals(String.valueOf($rightTerm)))"
+      }
+    }
+    // other type and string type
+    else if (isString(right.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"!($rightTerm.equals(String.valueOf($leftTerm)))"
+      }
     }
     // non-comparable types
     else {

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -175,4 +175,38 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		String expected = "bar\n" + "spam\n";
 		compareResultAsText(results, expected);
 	}
+
+	@Test
+	public void testImplicitConvertAtEqual() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		tableEnv.registerDataSet("T", ds, "a, b, c");
+
+		String sqlQuery = "SELECT * FROM T WHERE a = '1'";
+		Table result = tableEnv.sqlQuery(sqlQuery);
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "1,1,Hi\n";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testImplicitConvertAtNotEqual() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		tableEnv.registerDataSet("T", ds, "a, b, c");
+
+		String sqlQuery = "SELECT * FROM T WHERE a <> '1'";
+		Table result = tableEnv.sqlQuery(sqlQuery);
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "2,2,Hello\n" + "3,2,Hello world\n";
+		compareResultAsText(results, expected);
+	}
 }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -164,4 +164,53 @@ public class JavaSqlITCase extends AbstractTestBase {
 
 		StreamITCase.compareWithList(expected);
 	}
+
+	@Test
+	public void testImplicitConvertAtEqual() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamITCase.clear();
+
+		DataStream<Tuple3<Integer, Long, String>> ds =
+			JavaStreamTestData.getSmall3TupleDataSet(env);
+		Table t = tableEnv.fromDataStream(ds, "a, b, c");
+		tableEnv.registerTable("MyTable", t);
+
+		String sqlQuery = "SELECT * FROM MyTable WHERE a = '1'";
+		Table result = tableEnv.sqlQuery(sqlQuery);
+
+		DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink<Row>());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("1,1,Hi");
+
+		StreamITCase.compareWithList(expected);
+	}
+
+	@Test
+	public void testImplicitConvertAtNotEqual() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamITCase.clear();
+
+		DataStream<Tuple3<Integer, Long, String>> ds =
+			JavaStreamTestData.getSmall3TupleDataSet(env);
+		Table t = tableEnv.fromDataStream(ds, "a, b, c");
+		tableEnv.registerTable("MyTable", t);
+
+		String sqlQuery = "SELECT * FROM MyTable WHERE a <> '1'";
+		Table result = tableEnv.sqlQuery(sqlQuery);
+
+		DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink<Row>());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("2,2,Hello");
+		expected.add("3,2,Hello world");
+
+		StreamITCase.compareWithList(expected);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes the bug that implicit conversions in equals and notEquals filter predicates doesn't work


## Brief change log
Cast other types as string type when compare between string type and other types in `=` and `<>` predicates

## Verifying this change
This change added tests and can be verified as follows:
JavaSqlITCase#testImplicitConvertAtEqual
JavaSqlITCase#testImplicitConvertAtNotEqual

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
